### PR TITLE
Add threshold to sonar message

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektSensor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektSensor.kt
@@ -62,12 +62,15 @@ class DetektSensor : Sensor {
 		}
 	}
 
-	private fun NewIssue.primaryLocation(issue: Finding, inputFile: InputFile): NewIssue {
-		val line = issue.startPosition.line
+	private fun NewIssue.primaryLocation(finding: Finding, inputFile: InputFile): NewIssue {
+		val line = finding.startPosition.line
+		val metricMessages = finding.metrics
+				.map { "${it.type} ${it.value} is greater than the threshold ${it.threshold}." }
+				.joinToString(" ")
 		val newIssueLocation = newLocation()
 				.on(inputFile)
 				.at(inputFile.selectLine(line))
-				.message(issue.issue.description)
+				.message("${finding.issue.description} $metricMessages")
 		return this.at(newIssueLocation)
 	}
 


### PR DESCRIPTION
With this change the message in sonar will include e.g.
> SIZE 4 is greater than the threshold 3.
> MCC 12 is greater than the threshold 10.

Without this information it's not clear how to fix an issue.