### PR TITLE
Fix config loading and related tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
 	id "io.gitlab.arturbosch.detekt" version "1.0.0.RC4-3"
 }
 
+apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'kotlin'
 apply plugin: 'jacoco'
 
@@ -57,6 +58,13 @@ sourceSets {
 	main.java.srcDirs += 'src/main/kotlin'
 }
 
+junitPlatform {
+	filters {
+		engines {
+			include 'spek'
+		}
+	}
+}
 
 jacocoTestReport {
 	dependsOn test

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektConfiguration.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektConfiguration.kt
@@ -57,12 +57,12 @@ private fun tryFindDetektConfigurationFile(settings: Settings, baseDir: File): F
 		var configFile = File(path)
 
 		if (!configFile.exists() || configFile.endsWith(".yaml")) {
-			configFile = File(baseDir.path, configFile.path)
+			configFile = File(baseDir.path, path)
 		}
 		if (!configFile.exists() || configFile.endsWith(".yaml")) {
 			val parentFile = baseDir.parentFile
 			if (parentFile != null) {
-				configFile = File(parentFile.path, configFile.path)
+				configFile = File(parentFile.path, path)
 			} else {
 				return null
 			}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/LoadConfigSpec.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/LoadConfigSpec.kt
@@ -17,12 +17,12 @@ class LoadConfigSpec : Spek({
 
 	describe("try loading configuration file via property") {
 
-		val base = File(javaClass.getResource("/configBase/top-detekt-config.yml").toURI()).parentFile
+		val base = File(javaClass.getResource("/configBase/config/detekt-config.yml").toURI()).parentFile
 		assertThat(base).isNotNull()
 
 		it("should match config on sub path level") {
 			val settings = MapSettings().apply {
-				setProperty(CONFIG_PATH_KEY, File.separator + "config" + File.separator + "detekt-config.yml")
+				setProperty(CONFIG_PATH_KEY, "detekt-config.yml")
 			}
 			val config = chooseConfig(base, settings)
 
@@ -31,7 +31,7 @@ class LoadConfigSpec : Spek({
 
 		it("should match config top path level") {
 			val settings = MapSettings().apply {
-				setProperty(CONFIG_PATH_KEY, File.separator + "config" + File.separator + "top-detekt-config.yml")
+				setProperty(CONFIG_PATH_KEY, "top-detekt-config.yml")
 			}
 			val config = chooseConfig(base, settings)
 


### PR DESCRIPTION
This commit fixes `tryFindDetektConfigurationFile` by using String `path` instead of `configFile.path`, which is already an absolute path.

It also enables Spek (a Spek spec was added in 873800d86 but Spek was not enabled, so the spec was ignored and did not fail!).

I've also changed the spec itself, because `tryFindDetektConfigurationFile` looks for the config in `baseDir` and its _parent_, not in `baseDir` and its childs.