### PR TITLE
Update detekt to RC5-6 and adapt to new version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
 	compile "io.gitlab.arturbosch.detekt:detekt-core:$detektVersion"
-	compile "io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion"
+	compile "io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion"
 	compile "io.gitlab.arturbosch.detekt:detekt-rules:$detektVersion"
 	compileOnly "org.sonarsource.sonarqube:sonar-plugin-api:$sonarVersion"
 	compile "org.sonarsource.java:java-jacoco:4.11.0.10660"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-detektVersion=1.0.0.RC4-3
+detektVersion=1.0.0.RC5-6
 detektSonarVersion=0.2.4
-usedDetektGradlePlugin=1.0.0.RC4-3
+usedDetektGradlePlugin=1.0.0.RC5-6
 kotlinVersion=1.1.3-2
 spekVersion=1.1.5
 junitPlatformVersion=1.0.0

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/FileMeasurementStorage.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/FileMeasurementStorage.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.sonar.sensor
 
-import io.gitlab.arturbosch.detekt.core.processors.COMPLEXITY_KEY
-import io.gitlab.arturbosch.detekt.core.processors.NUMBER_OF_COMMENT_LINES_KEY
-import io.gitlab.arturbosch.detekt.core.processors.SLOC_KEY
+import io.gitlab.arturbosch.detekt.core.processors.complexityKey
+import io.gitlab.arturbosch.detekt.core.processors.commentLinesKey
+import io.gitlab.arturbosch.detekt.core.processors.sourceLinesKey
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
 import org.sonar.api.batch.fs.InputComponent
@@ -18,9 +18,9 @@ import org.sonar.api.measures.Metric
 class FileMeasurementStorage(private val context: SensorContext) {
 
 	fun save(file: KtFile, inputComponent: InputComponent) {
-		save(file, inputComponent, SLOC_KEY, NCLOC)
-		save(file, inputComponent, NUMBER_OF_COMMENT_LINES_KEY, COMMENT_LINES)
-		save(file, inputComponent, COMPLEXITY_KEY, COMPLEXITY)
+		save(file, inputComponent, sourceLinesKey, NCLOC)
+		save(file, inputComponent, commentLinesKey, COMMENT_LINES)
+		save(file, inputComponent, complexityKey, COMPLEXITY)
 	}
 
 	private fun save(file: KtFile, inputComponent: InputComponent,

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/FileProcessor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/FileProcessor.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.sonar.sensor
 
-import io.gitlab.arturbosch.detekt.core.KtCompiler
+import io.gitlab.arturbosch.detekt.core.relativePath
 import io.gitlab.arturbosch.detekt.sonar.foundation.KotlinSyntax
 import org.jetbrains.kotlin.psi.KtFile
 import org.sonar.api.batch.sensor.SensorContext
@@ -15,8 +15,11 @@ class FileProcessor(private val context: SensorContext,
 	private val fileSystem = context.fileSystem()
 
 	fun run() {
+		val base = context.fileSystem().baseDir().toPath()
 		for (ktFile in ktFiles) {
-			fileSystem.inputFile { it.relativePath() == ktFile.getUserData(KtCompiler.RELATIVE_PATH) }?.let {
+			fileSystem.inputFile {
+				base.fileName.resolve(it.relativePath()).toString() == ktFile.relativePath()
+			}?.let {
 				fileStorage.save(ktFile, it)
 				KotlinSyntax.processFile(it, ktFile, context)
 			}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/IssueReporter.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/IssueReporter.kt
@@ -29,7 +29,7 @@ class IssueReporter(private val detektion: Detektion,
 			LOG.info("Invalid location for ${issue.compactWithSignature()}.")
 			return
 		}
-		val pathOfIssue = baseDir.resolve(issue.location.file)
+		val pathOfIssue = baseDir.resolveSibling(issue.location.file)
 		val inputFile = fileSystem.inputFile(fileSystem.predicates().`is`(pathOfIssue))
 		if (inputFile != null) {
 			RULE_KEY_LOOKUP[issue.id]?.let {

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/ProjectMeasurementStorage.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/ProjectMeasurementStorage.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.sonar.sensor
 
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.core.processors.COMPLEXITY_KEY
-import io.gitlab.arturbosch.detekt.core.processors.LLOC_KEY
-import io.gitlab.arturbosch.detekt.core.processors.LOC_KEY
-import io.gitlab.arturbosch.detekt.core.processors.NUMBER_OF_COMMENT_LINES_KEY
-import io.gitlab.arturbosch.detekt.core.processors.SLOC_KEY
+import io.gitlab.arturbosch.detekt.core.processors.complexityKey
+import io.gitlab.arturbosch.detekt.core.processors.logicalLinesKey
+import io.gitlab.arturbosch.detekt.core.processors.linesKey
+import io.gitlab.arturbosch.detekt.core.processors.commentLinesKey
+import io.gitlab.arturbosch.detekt.core.processors.sourceLinesKey
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.sonar.api.batch.sensor.SensorContext
 import org.sonar.api.measures.Metric
@@ -14,11 +14,11 @@ class ProjectMeasurementStorage(private val detektion: Detektion,
 								private val context: SensorContext) {
 
 	fun run() {
-		save(LOC_KEY, LOC_PROJECT)
-		save(SLOC_KEY, SLOC_PROJECT)
-		save(LLOC_KEY, LLOC_PROJECT)
-		save(NUMBER_OF_COMMENT_LINES_KEY, CLOC_PROJECT)
-		save(COMPLEXITY_KEY, MCCABE_PROJECT)
+		save(linesKey, LOC_PROJECT)
+		save(sourceLinesKey, SLOC_PROJECT)
+		save(logicalLinesKey, LLOC_PROJECT)
+		save(commentLinesKey, CLOC_PROJECT)
+		save(complexityKey, MCCABE_PROJECT)
 	}
 
 	private fun save(dataKey: Key<Int>, metricKey: Metric<Int>) {


### PR DESCRIPTION
The main difference that needed adaptation came from https://github.com/arturbosch/detekt/commit/a380ad2e26a5174a89345b5058f6de1734218a19 (in https://github.com/arturbosch/detekt/pull/510), which prepends the project name to finding paths.