### PR TITLE
Locate java resources when reporting coverage

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJavaResourceLocator.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJavaResourceLocator.kt
@@ -6,16 +6,23 @@ import org.sonar.api.batch.fs.FileSystem
 import org.sonar.api.batch.fs.InputFile
 import org.sonar.plugins.java.api.JavaResourceLocator
 
+/**
+ * Locate kotlin or java input file for given class name.
+ */
 @Suppress("ALL")
 class KotlinJavaResourceLocator(
-		delegate: JavaResourceLocator,
-		private val fileSystem: FileSystem) : JavaResourceLocator by delegate {
+        private val javaResourceLocator: JavaResourceLocator,
+        private val fileSystem: FileSystem) : JavaResourceLocator by javaResourceLocator {
 
 	override fun findResourceByClassName(className: String): InputFile? {
-		val filePredicates = fileSystem.predicates()
-		return fileSystem.inputFile(filePredicates.and(
-				filePredicates.matchesPathPattern("**/" + className.replace('.', '/') + FILE_SUFFIX),
-				filePredicates.hasLanguage(KEY),
-				filePredicates.hasType(InputFile.Type.MAIN)))
+        return kotlinResource(className) ?: javaResourceLocator.findResourceByClassName(className)
+	}
+
+	private fun kotlinResource(className: String): InputFile? {
+        val filePredicates = fileSystem.predicates()
+        return fileSystem.inputFile(filePredicates.and(
+                filePredicates.matchesPathPattern("**/" + className.replace('.', '/') + FILE_SUFFIX),
+                filePredicates.hasLanguage(KEY),
+                filePredicates.hasType(InputFile.Type.MAIN)))
 	}
 }

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJavaResourceLocatorTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJavaResourceLocatorTest.kt
@@ -1,0 +1,52 @@
+package io.gitlab.arturbosch.detekt.sonar.jacoco
+
+import com.nhaarman.mockito_kotlin.anyOrNull
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.sonar.api.batch.fs.FilePredicates
+import org.sonar.api.batch.fs.FileSystem
+import org.sonar.api.batch.fs.InputFile
+import org.sonar.plugins.java.api.JavaResourceLocator
+
+val className = "foo.Bar"
+
+class KotlinJavaResourceLocatorTest : Spek({
+    val javaLocator: JavaResourceLocator = mock()
+    val fileSystem: FileSystem = mock()
+    val predicates: FilePredicates = mock()
+    val kotlinFile: InputFile = mock(name = "Bar.kt")
+    val javaFile: InputFile = mock(name = "Bar.java")
+    whenever(fileSystem.predicates()).thenReturn(predicates)
+
+    describe("a locator") {
+
+        val locator = KotlinJavaResourceLocator(javaLocator, fileSystem)
+
+        on("kotlin file present") {
+            whenever(fileSystem.inputFile(anyOrNull())).thenReturn(kotlinFile)
+
+            it("should find kotlin resource") {
+                assertThat(locator.findResourceByClassName(className)).isEqualTo(kotlinFile)
+            }
+        }
+
+        on("no kotlin file present") {
+            whenever(fileSystem.inputFile(anyOrNull())).thenReturn(null)
+
+            it("should find java resource") {
+                whenever(javaLocator.findResourceByClassName(className)).thenReturn(javaFile)
+                assertThat(locator.findResourceByClassName(className)).isEqualTo(javaFile)
+            }
+
+            it ("should return null if no java resource") {
+                whenever(javaLocator.findResourceByClassName(className)).thenReturn(null)
+                assertThat(locator.findResourceByClassName(className)).isNull()
+            }
+        }
+    }
+})


### PR DESCRIPTION
There can be kotlin tests testing java files.
Coverage should be reported by Kotlin sonar plugin