### PR TITLE
Update detekt for Java9 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 plugins {
 	id "com.iadams.sonar-packaging" version "1.0-RC1"
 	id "org.sonarqube" version "2.5"
-	id "io.gitlab.arturbosch.detekt" version "1.0.0.RC4-3"
+	id "io.gitlab.arturbosch.detekt" version "1.0.0.RC6-1"
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-detektVersion=1.0.0.RC5-6
+detektVersion=1.0.0.RC6-1
 detektSonarVersion=0.3.0
-usedDetektGradlePlugin=1.0.0.RC5-6
+usedDetektGradlePlugin=1.0.0.RC6-1
 kotlinVersion=1.1.3-2
 spekVersion=1.1.5
 junitPlatformVersion=1.0.0

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektSensor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektSensor.kt
@@ -19,14 +19,16 @@ class DetektSensor : Sensor {
 
 	override fun execute(context: SensorContext) {
 		val settings = createProcessingSettings(context)
-		val detektor = DetektFacade.instance(settings)
+		val detektor = DetektFacade.create(settings)
 		val compiler = KtTreeCompiler.instance(settings)
 
-		val ktFiles = compiler.compile()
-		val detektion = detektor.run(ktFiles)
+		settings.project.forEach {
+			val ktFiles = compiler.compile(it)
+			val detektion = detektor.run(it, ktFiles)
 
-		IssueReporter(detektion, context).run()
-		ProjectMeasurementStorage(detektion, context).run()
-		FileProcessor(context, ktFiles).run()
+			IssueReporter(detektion, context).run()
+			ProjectMeasurementStorage(detektion, context).run()
+			FileProcessor(context, ktFiles).run()
+		}
 	}
 }


### PR DESCRIPTION
When analyzing a project in Java9, I ran into the error corrected in https://github.com/arturbosch/detekt/issues/566
This MR update detekt library and version of Kotlin