### PR TITLE
Implement Surefire Parsing

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektPlugin.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektPlugin.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.sonar.profiles.KotlinProfile
 import io.gitlab.arturbosch.detekt.sonar.rules.DetektRulesDefinition
 import io.gitlab.arturbosch.detekt.sonar.sensor.DetektMetrics
 import io.gitlab.arturbosch.detekt.sonar.sensor.DetektSensor
+import io.gitlab.arturbosch.detekt.sonar.surefire.KotlinSurefireParser
+import io.gitlab.arturbosch.detekt.sonar.surefire.KotlinSurefireSensor
 import org.sonar.api.Plugin
 import org.sonar.java.JavaClasspath
 import org.sonar.java.JavaTestClasspath
@@ -27,7 +29,10 @@ class DetektPlugin : Plugin {
 				JavaClasspath::class.java,
 				JavaTestClasspath::class.java,
 				KotlinJaCoCoSensor::class.java,
-				JacocoConfiguration::class.java
+				JacocoConfiguration::class.java,
+				// Tests
+				KotlinSurefireSensor::class.java,
+				KotlinSurefireParser::class.java
 		))
 		context.addExtensions(propertyDefinitions)
 	}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/KotlinSurefireParser.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/KotlinSurefireParser.kt
@@ -1,0 +1,206 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire
+
+import io.gitlab.arturbosch.detekt.sonar.foundation.FILE_SUFFIX
+import io.gitlab.arturbosch.detekt.sonar.foundation.KEY
+import io.gitlab.arturbosch.detekt.sonar.surefire.data.UnitTestClassReport
+import io.gitlab.arturbosch.detekt.sonar.surefire.data.UnitTestIndex
+import org.apache.commons.lang.StringUtils
+import org.sonar.api.batch.ScannerSide
+import org.sonar.api.batch.fs.FilePredicate
+import org.sonar.api.batch.fs.FilePredicates
+import org.sonar.api.batch.fs.FileSystem
+import org.sonar.api.batch.fs.InputFile
+import org.sonar.api.batch.sensor.SensorContext
+import org.sonar.api.component.ResourcePerspectives
+import org.sonar.api.measures.CoreMetrics
+import org.sonar.api.measures.Metric
+import org.sonar.api.test.MutableTestPlan
+import org.sonar.api.test.TestCase
+import org.sonar.api.utils.log.Loggers
+import org.sonar.squidbridge.api.AnalysisException
+import java.io.File
+import java.io.Serializable
+import java.util.*
+import javax.xml.stream.XMLStreamException
+
+@ScannerSide
+class KotlinSurefireParser(
+        private val perspectives: ResourcePerspectives,
+        val fileSystem: FileSystem
+) {
+
+    fun collect(context: SensorContext, reportsDirs: List<File>, reportDirSetByUser: Boolean) {
+        val xmlFiles = getReports(reportsDirs, reportDirSetByUser)
+        if (!xmlFiles.isEmpty()) {
+            parseFiles(context, xmlFiles)
+        }
+    }
+
+    private fun parseFiles(context: SensorContext, reports: List<File>) {
+        val index = UnitTestIndex()
+        parseFiles(reports, index)
+        sanitize(index)
+        save(index, context)
+    }
+
+    private fun save(index: UnitTestIndex, context: SensorContext) {
+        var negativeTimeTestNumber: Long = 0
+        val indexByInputFile = mapToInputFile(index.indexByClassname)
+        for ((key, report) in indexByInputFile) {
+            if (report.tests > 0) {
+                negativeTimeTestNumber += report.negativeTimeTestNumber
+                save(report, key, context)
+            }
+        }
+        if (negativeTimeTestNumber > 0) {
+            LOGGER.warn("There is {} test(s) reported with negative time by surefire, total duration may not be accurate.", negativeTimeTestNumber)
+        }
+    }
+
+    private fun mapToInputFile(indexByClassname: Map<String, UnitTestClassReport>): Map<InputFile, UnitTestClassReport> {
+        val result = HashMap<InputFile, UnitTestClassReport>()
+        indexByClassname.forEach { className, index ->
+            val resource = getUnitTestResource(className, index)
+            if (resource != null) {
+                val report = (result as java.util.Map<InputFile, UnitTestClassReport>).computeIfAbsent(resource) { UnitTestClassReport() }
+                // in case of repeated/parameterized tests (JUnit 5.x) we may end up with tests having the same name
+                index.results.forEach { report.add(it) }
+            } else {
+                LOGGER.debug("Resource not found: {}", className)
+            }
+        }
+        return result
+    }
+
+    private fun save(report: UnitTestClassReport, inputFile: InputFile, context: SensorContext) {
+        val testsCount = report.tests - report.skipped
+        saveMeasure(context, inputFile, CoreMetrics.SKIPPED_TESTS, report.skipped)
+        saveMeasure(context, inputFile, CoreMetrics.TESTS, testsCount)
+        saveMeasure(context, inputFile, CoreMetrics.TEST_ERRORS, report.errors)
+        saveMeasure(context, inputFile, CoreMetrics.TEST_FAILURES, report.failures)
+        saveMeasure(context, inputFile, CoreMetrics.TEST_EXECUTION_TIME, report.durationMilliseconds)
+        saveResults(inputFile, report)
+    }
+
+    private fun saveResults(testFile: InputFile, report: UnitTestClassReport) {
+        for (unitTestResult in report.results) {
+            val testPlan = perspectives.`as`(MutableTestPlan::class.java, testFile)
+            testPlan?.addTestCase(unitTestResult.name)
+                    ?.setDurationInMs(Math.max(unitTestResult.durationMilliseconds, 0))
+                    ?.setStatus(TestCase.Status.of(unitTestResult.status))
+                    ?.setMessage(unitTestResult.message)
+                    ?.setStackTrace(unitTestResult.stackTrace)
+        }
+    }
+
+    private fun getUnitTestResource(className: String, unitTestClassReport: UnitTestClassReport): InputFile? {
+        return findKotlinTestByClassname(className)
+                ?: // fall back on testSuite class name (repeated and parameterized tests from JUnit 5.0 are using test name as classname)
+                // Should be fixed with JUnit 5.1, see: https://github.com/junit-team/junit5/issues/1182
+                return unitTestClassReport.results
+                        .filter { it.testSuiteClassName != null }
+                        .map { findKotlinTestByClassname(it.testSuiteClassName!!) }
+                        .firstOrNull { it != null }
+    }
+
+    private fun findKotlinTestByClassname(className: String): InputFile? {
+        val fileName = StringUtils.replace(className, ".", "/")
+        val p = fileSystem.predicates()
+        val fileNamePredicates = getFileNamePredicateFromSuffixes(p, fileName, arrayOf(FILE_SUFFIX))
+        val searchPredicate = p.and(p.and(p.hasLanguage(KEY), p.hasType(InputFile.Type.TEST)), fileNamePredicates)
+        return if (fileSystem.hasFiles(searchPredicate)) {
+            fileSystem.inputFiles(searchPredicate).iterator().next()
+        } else {
+            null
+        }
+    }
+
+    private fun getFileNamePredicateFromSuffixes(p: FilePredicates, fileName: String, suffixes: Array<String>): FilePredicate {
+        val fileNamePredicates = ArrayList<FilePredicate>(suffixes.size)
+        for (suffix in suffixes) {
+            fileNamePredicates.add(p.matchesPathPattern("**/$fileName$suffix"))
+        }
+        return p.or(fileNamePredicates)
+    }
+
+    companion object {
+
+        private val LOGGER = Loggers.get(KotlinSurefireParser::class.java)
+
+        private fun getReports(dirs: List<File>, reportDirSetByUser: Boolean): List<File> {
+            return dirs
+                    .map { getReports(it, reportDirSetByUser) }
+                    .flatMap { it }
+                    .toList()
+        }
+
+        private fun getReports(dir: File, reportDirSetByUser: Boolean): List<File> {
+            if (!dir.isDirectory) {
+                if (reportDirSetByUser) {
+                    LOGGER.error("Reports path not found or is not a directory: " + dir.absolutePath)
+                }
+                return emptyList()
+            }
+            var unitTestResultFiles = findXMLFilesStartingWith(dir, "TEST-")
+            if (unitTestResultFiles.isEmpty()) {
+                // maybe there's only a test suite result file
+                unitTestResultFiles = findXMLFilesStartingWith(dir, "TESTS-")
+            }
+            if (unitTestResultFiles.isEmpty()) {
+                LOGGER.warn("Reports path contains no files matching TEST-.*.xml : " + dir.absolutePath)
+            }
+            return unitTestResultFiles.toList()
+        }
+
+        private fun findXMLFilesStartingWith(dir: File, fileNameStart: String): Array<File> {
+            return dir.listFiles { parentDir, name -> name.startsWith(fileNameStart) && name.endsWith(".xml") }
+                    ?: emptyArray()
+        }
+
+        private fun parseFiles(reports: List<File>, index: UnitTestIndex) {
+            val parser = StaxParser(index)
+            for (report in reports) {
+                try {
+                    parser.parse(report)
+                } catch (e: XMLStreamException) {
+                    throw AnalysisException("Fail to parse the Surefire report: $report", e)
+                }
+
+            }
+        }
+
+        private fun sanitize(index: UnitTestIndex) {
+            for (classname in index.classnames) {
+                if (StringUtils.contains(classname, "$")) {
+                    // Surefire reports classes whereas sonar supports files
+                    val parentClassName = StringUtils.substringBefore(classname, "$")
+                    index.merge(classname, parentClassName)
+                }
+            }
+        }
+
+        private fun <T : Serializable> saveMeasure(context: SensorContext, inputFile: InputFile, metric: Metric<T>, value: T) {
+            context.newMeasure<T>().forMetric(metric).on(inputFile).withValue(value).save()
+        }
+    }
+
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/KotlinSurefireSensor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/KotlinSurefireSensor.kt
@@ -1,0 +1,66 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire
+
+import io.gitlab.arturbosch.detekt.sonar.foundation.KEY
+import io.gitlab.arturbosch.detekt.sonar.surefire.api.SurefireUtils
+import org.sonar.api.batch.DependedUpon
+import org.sonar.api.batch.fs.FileSystem
+import org.sonar.api.batch.sensor.Sensor
+import org.sonar.api.batch.sensor.SensorContext
+import org.sonar.api.batch.sensor.SensorDescriptor
+import org.sonar.api.config.Configuration
+import org.sonar.api.scan.filesystem.PathResolver
+import org.sonar.api.utils.log.Loggers
+import java.io.File
+
+@DependedUpon("surefire-java")
+class KotlinSurefireSensor(
+        private val kotlinSurefireParser: KotlinSurefireParser,
+        private val configuration: Configuration,
+        private val fs: FileSystem,
+        private val pathResolver: PathResolver
+) : Sensor {
+
+    override fun describe(descriptor: SensorDescriptor) {
+        descriptor.onlyOnLanguage(KEY).name("KotlinSurefireSensor")
+    }
+
+    override fun execute(context: SensorContext) {
+        val dir = SurefireUtils.getReportsDirectories(configuration, fs, pathResolver).distinct()
+        collect(context, dir)
+    }
+
+    private fun collect(context: SensorContext, reportsDir: List<File>) {
+        LOGGER.info("parsing {}", reportsDir)
+        kotlinSurefireParser.collect(context, reportsDir,
+                configuration.hasKey(SurefireUtils.SUREFIRE_REPORT_PATHS_PROPERTY)
+                        || configuration.hasKey(SurefireUtils.SUREFIRE_REPORTS_PATH_PROPERTY))
+    }
+
+    override fun toString(): String {
+        return javaClass.simpleName
+    }
+
+    companion object {
+        private val LOGGER = Loggers.get(KotlinSurefireSensor::class.java)
+    }
+
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/StaxParser.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/StaxParser.kt
@@ -1,0 +1,70 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire
+
+import com.ctc.wstx.stax.WstxInputFactory
+import io.gitlab.arturbosch.detekt.sonar.surefire.data.SurefireStaxHandler
+import io.gitlab.arturbosch.detekt.sonar.surefire.data.UnitTestIndex
+import org.codehaus.staxmate.SMInputFactory
+import org.codehaus.staxmate.`in`.SMHierarchicCursor
+
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamException
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+
+internal class StaxParser(index: UnitTestIndex) {
+
+    private val inf: SMInputFactory
+    private val streamHandler: SurefireStaxHandler = SurefireStaxHandler(index)
+
+    init {
+        val xmlFactory = XMLInputFactory.newInstance()
+        if (xmlFactory is WstxInputFactory) {
+            xmlFactory.configureForLowMemUsage()
+            xmlFactory.config.setUndeclaredEntityResolver { _: String, _: String, _: String, namespace: String ->
+                namespace
+            }
+        }
+        xmlFactory.setProperty(XMLInputFactory.IS_VALIDATING, false)
+        xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
+        xmlFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
+        inf = SMInputFactory(xmlFactory)
+    }
+
+    @Throws(XMLStreamException::class)
+    fun parse(xmlFile: File) {
+        try {
+            FileInputStream(xmlFile).use { input -> parse(inf.rootElementCursor(input)) }
+        } catch (e: IOException) {
+            throw XMLStreamException(e)
+        }
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun parse(rootCursor: SMHierarchicCursor) {
+        try {
+            streamHandler.stream(rootCursor)
+        } finally {
+            rootCursor.streamReader.closeCompletely()
+        }
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/api/SurefireUtils.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/api/SurefireUtils.kt
@@ -1,0 +1,98 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire.api
+
+import java.io.File
+import java.util.Arrays
+import java.util.Collections
+import java.util.Objects
+import java.util.stream.Collectors
+import org.sonar.api.batch.fs.FileSystem
+import org.sonar.api.config.Configuration
+import org.sonar.api.scan.filesystem.PathResolver
+import org.sonar.api.utils.log.Logger
+import org.sonar.api.utils.log.Loggers
+
+object SurefireUtils {
+
+    private val LOGGER = Loggers.get(SurefireUtils::class.java)
+
+    @Deprecated("since 4.11")
+    val SUREFIRE_REPORTS_PATH_PROPERTY = "sonar.junit.reportsPath"
+    val SUREFIRE_REPORT_PATHS_PROPERTY = "sonar.junit.reportPaths"
+
+    /**
+     * Find the directories containing the surefire reports.
+     * @param settings Analysis settings.
+     * @param fs FileSystem containing indexed files.
+     * @param pathResolver Path solver.
+     * @return The directories containing the surefire reports or default one (target/surefire-reports) if not found (not configured or not found).
+     */
+    fun getReportsDirectories(settings: Configuration, fs: FileSystem, pathResolver: PathResolver): List<File> {
+        val dir = getReportsDirectoryFromDeprecatedProperty(settings, fs, pathResolver)
+        val dirs = getReportsDirectoriesFromProperty(settings, fs, pathResolver)
+        if (dirs != null) {
+            if (dir != null) {
+                // both properties are set, deprecated property ignored
+                LOGGER.debug("Property '{}' is deprecated and will be ignored, as property '{}' is also set.", SUREFIRE_REPORTS_PATH_PROPERTY, SUREFIRE_REPORT_PATHS_PROPERTY)
+            }
+            return dirs
+        }
+        if (dir != null) {
+            LOGGER.info("Property '{}' is deprecated. Use property '{}' instead.", SUREFIRE_REPORTS_PATH_PROPERTY, SUREFIRE_REPORT_PATHS_PROPERTY)
+            return listOf(dir)
+        }
+        // both properties are not set
+        return listOf(File(fs.baseDir(), "target/surefire-reports"))
+    }
+
+    private fun getReportsDirectoriesFromProperty(settings: Configuration, fs: FileSystem, pathResolver: PathResolver): List<File>? {
+        return if (settings.hasKey(SUREFIRE_REPORT_PATHS_PROPERTY)) {
+            settings.getStringArray(SUREFIRE_REPORT_PATHS_PROPERTY)
+                    .map { it.trim() }
+                    .map { getFileFromPath(fs, pathResolver, it) }
+                    .filter { it != null }
+                    .map { it!! }
+                    .toList()
+        } else null
+    }
+
+    private fun getReportsDirectoryFromDeprecatedProperty(settings: Configuration, fs: FileSystem, pathResolver: PathResolver): File? {
+        if (settings.hasKey(SUREFIRE_REPORTS_PATH_PROPERTY)) {
+            val path = settings.get(SUREFIRE_REPORTS_PATH_PROPERTY).orElse(null)
+            if (path != null) {
+                return getFileFromPath(fs, pathResolver, path)
+            }
+        }
+        return null
+    }
+
+    private fun getFileFromPath(fs: FileSystem, pathResolver: PathResolver, path: String): File? {
+        try {
+            return pathResolver.relativeFile(fs.baseDir(), path)
+        } catch (e: Exception) {
+            // exceptions on file not found was only occurring with SQ 5.6 LTS, not with SQ 6.4
+            LOGGER.info("Surefire report path: {}/{} not found.", fs.baseDir(), path)
+        }
+
+        return null
+    }
+
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/SurefireStaxHandler.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/SurefireStaxHandler.kt
@@ -1,0 +1,150 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire.data
+
+import java.text.ParseException
+import java.util.Locale
+import javax.xml.stream.XMLStreamException
+import org.apache.commons.lang.StringUtils
+import org.codehaus.staxmate.`in`.ElementFilter
+import org.codehaus.staxmate.`in`.SMEvent
+import org.codehaus.staxmate.`in`.SMHierarchicCursor
+import org.codehaus.staxmate.`in`.SMInputCursor
+import org.sonar.api.utils.ParsingUtils
+
+class SurefireStaxHandler(private val index: UnitTestIndex) {
+
+    @Throws(XMLStreamException::class)
+    fun stream(rootCursor: SMHierarchicCursor) {
+        val testSuite = rootCursor.constructDescendantCursor(ElementFilter("testsuite"))
+        var testSuiteEvent: SMEvent?
+        testSuiteEvent = testSuite.next
+        while (testSuiteEvent != null) {
+            if (testSuiteEvent.compareTo(SMEvent.START_ELEMENT) == 0) {
+                val testSuiteClassName = testSuite.getAttrValue("name")
+                if (StringUtils.contains(testSuiteClassName, "$")) {
+                    // test suites for inner classes are ignored
+                    return
+                }
+                parseTestCase(testSuiteClassName, testSuite.childCursor(ElementFilter("testcase")))
+            }
+            testSuiteEvent = testSuite.next
+        }
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun parseTestCase(testSuiteClassName: String, testCase: SMInputCursor) {
+        var event: SMEvent? = testCase.next
+        while (event != null) {
+            if (event.compareTo(SMEvent.START_ELEMENT) == 0) {
+                val testClassName = getClassname(testCase, testSuiteClassName)
+                val classReport = index.index(testClassName)
+                parseTestCase(testCase, testSuiteClassName, classReport)
+            }
+            event = testCase.next
+        }
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun getClassname(testCaseCursor: SMInputCursor, defaultClassname: String): String {
+        var testClassName = testCaseCursor.getAttrValue("classname")
+        if (StringUtils.isNotBlank(testClassName) && testClassName.endsWith(")")) {
+            testClassName = testClassName.substring(0, testClassName.indexOf('('))
+        }
+        return StringUtils.defaultIfBlank(testClassName, defaultClassname)
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun parseTestCase(testCaseCursor: SMInputCursor, testSuiteClassName: String, report: UnitTestClassReport) {
+        report.add(parseTestResult(testCaseCursor, testSuiteClassName))
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun setStackAndMessage(result: UnitTestResult, stackAndMessageCursor: SMInputCursor) {
+        result.message = stackAndMessageCursor.getAttrValue("message")
+        val stack = stackAndMessageCursor.collectDescendantText()
+        result.stackTrace = stack
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun parseTestResult(testCaseCursor: SMInputCursor, testSuiteClassName: String): UnitTestResult {
+        val detail = UnitTestResult()
+        val name = getTestCaseName(testCaseCursor)
+        detail.name = name
+        detail.testSuiteClassName = testSuiteClassName
+
+        var status = UnitTestResult.STATUS_OK
+        val time = testCaseCursor.getAttrValue("time")
+        var duration: Long? = null
+
+        val childNode = testCaseCursor.descendantElementCursor()
+        if (childNode.next != null) {
+            val elementName = childNode.localName
+            when (elementName) {
+                "skipped" -> {
+                    status = UnitTestResult.STATUS_SKIPPED
+                    // bug with surefire reporting wrong time for skipped tests
+                    duration = 0L
+
+                }
+                "failure" -> {
+                    status = UnitTestResult.STATUS_FAILURE
+                    setStackAndMessage(detail, childNode)
+
+                }
+                "error" -> {
+                    status = UnitTestResult.STATUS_ERROR
+                    setStackAndMessage(detail, childNode)
+                }
+            }
+        }
+        while (childNode.next != null) {
+            // make sure we loop till the end of the elements cursor
+        }
+        if (duration == null) {
+            duration = getTimeAttributeInMS(time)
+        }
+        detail.durationMilliseconds = duration
+        detail.status = status
+        return detail
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun getTimeAttributeInMS(value: String): Long {
+        // hardcoded to Locale.ENGLISH see http://jira.codehaus.org/browse/SONAR-602
+        try {
+            val time = ParsingUtils.parseNumber(value, Locale.ENGLISH)
+            return if (!java.lang.Double.isNaN(time)) ParsingUtils.scaleValue(time * 1000, 3).toLong() else 0L
+        } catch (e: ParseException) {
+            throw XMLStreamException(e)
+        }
+
+    }
+
+    @Throws(XMLStreamException::class)
+    private fun getTestCaseName(testCaseCursor: SMInputCursor): String {
+        val classname = testCaseCursor.getAttrValue("classname")
+        val name = testCaseCursor.getAttrValue("name")
+        return if (StringUtils.contains(classname, "$")) {
+            StringUtils.substringAfter(classname, "$") + "/" + name
+        } else name
+    }
+
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/UnitTestClassReport.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/UnitTestClassReport.kt
@@ -1,0 +1,56 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire.data
+
+data class UnitTestClassReport(
+        var errors: Int = 0,
+        var failures: Int = 0,
+        var skipped: Int = 0,
+        var tests: Int = 0,
+        var durationMilliseconds: Long = 0L,
+        var negativeTimeTestNumber: Long = 0L,
+        val results: MutableList<UnitTestResult> = mutableListOf()
+) {
+
+
+    fun add(other: UnitTestClassReport): UnitTestClassReport {
+        for (otherResult in other.results) {
+            add(otherResult)
+        }
+        return this
+    }
+
+    fun add(result: UnitTestResult): UnitTestClassReport {
+        results.add(result)
+        when {
+            result.status == UnitTestResult.STATUS_SKIPPED -> skipped += 1
+            result.status == UnitTestResult.STATUS_FAILURE -> failures += 1
+            result.status == UnitTestResult.STATUS_ERROR -> errors += 1
+        }
+        tests += 1
+        if (result.durationMilliseconds < 0) {
+            negativeTimeTestNumber += 1
+        } else {
+            durationMilliseconds += result.durationMilliseconds
+        }
+        return this
+    }
+
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/UnitTestIndex.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/UnitTestIndex.kt
@@ -1,0 +1,53 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire.data
+
+import com.google.common.collect.Maps
+import com.google.common.collect.Sets
+
+class UnitTestIndex {
+
+    val indexByClassname: MutableMap<String, UnitTestClassReport>
+    val classnames: Set<String> get() = Sets.newHashSet(indexByClassname.keys)
+
+    init {
+        this.indexByClassname = Maps.newHashMap()
+    }
+
+    fun index(classname: String): UnitTestClassReport {
+        return indexByClassname.computeIfAbsent(classname) { UnitTestClassReport() }
+    }
+
+    operator fun get(classname: String): UnitTestClassReport? {
+        return indexByClassname[classname]
+    }
+
+    fun merge(classname: String, intoClassname: String): UnitTestClassReport? {
+        val from = indexByClassname[classname]
+        if (from != null) {
+            val to = index(intoClassname)
+            to.add(from)
+            indexByClassname.remove(classname)
+            return to
+        }
+        return null
+    }
+
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/UnitTestResult.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/data/UnitTestResult.kt
@@ -1,0 +1,40 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.gitlab.arturbosch.detekt.sonar.surefire.data
+
+data class UnitTestResult(
+        var name: String? = null,
+        var testSuiteClassName: String? = null,
+        var status: String? = null,
+        var stackTrace: String? = null,
+        var message: String? = null,
+        var durationMilliseconds: Long = 0L
+) {
+    val isErrorOrFailure: Boolean get() = STATUS_ERROR == status || STATUS_FAILURE == status
+
+    val isError: Boolean get() = STATUS_ERROR == status
+
+    companion object {
+        val STATUS_OK = "ok"
+        val STATUS_ERROR = "error"
+        val STATUS_FAILURE = "failure"
+        val STATUS_SKIPPED = "skipped"
+    }
+}


### PR DESCRIPTION
Maven Surefire format defines the tests which run, succeeded or failed.
Parsing this report is crucial to have an indication on SonarQube about
the number of existing Kotlin tests.

Implement thus this feature by using the same approach taken by
Sonarsource in sonar-groovy, where they had to copy and then customise
classes from sonar-java.

Unlike sonar-groovy, use non-deprecated SonarQube classes and methods.