### PR TITLE
Updating java-jacoco version so it works on sonarqube 7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>java-jacoco</artifactId>
-            <version>4.11.0.10660</version>
+            <version>5.7.0.15470</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektPlugin.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektPlugin.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.sonar.surefire.KotlinSurefireSensor
 import org.sonar.api.Plugin
 import org.sonar.java.JavaClasspath
 import org.sonar.java.JavaTestClasspath
-import org.sonar.plugins.jacoco.JacocoConfiguration
 
 /**
  * @author Artur Bosch
@@ -29,7 +28,6 @@ class DetektPlugin : Plugin {
 				JavaClasspath::class.java,
 				JavaTestClasspath::class.java,
 				KotlinJaCoCoSensor::class.java,
-				JacocoConfiguration::class.java,
 				// Tests
 				KotlinSurefireSensor::class.java,
 				KotlinSurefireParser::class.java

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJaCoCoSensor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJaCoCoSensor.kt
@@ -27,12 +27,8 @@ import org.sonar.api.batch.sensor.SensorContext
 import org.sonar.api.batch.sensor.SensorDescriptor
 import org.sonar.api.config.Configuration
 import org.sonar.java.JavaClasspath
-import org.sonar.plugins.jacoco.JaCoCoExtensions.LOG
+import org.sonar.plugins.jacoco.JaCoCoExtensions.*
 import org.sonar.plugins.jacoco.JaCoCoReportMerger
-import org.sonar.plugins.jacoco.JacocoConfiguration.IT_REPORT_PATH_PROPERTY
-import org.sonar.plugins.jacoco.JacocoConfiguration.REPORT_MISSING_FORCE_ZERO
-import org.sonar.plugins.jacoco.JacocoConfiguration.REPORT_PATHS_PROPERTY
-import org.sonar.plugins.jacoco.JacocoConfiguration.REPORT_PATH_PROPERTY
 import org.sonar.plugins.java.api.JavaResourceLocator
 import java.io.File
 import java.util.*

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/KotlinSurefireParser.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/surefire/KotlinSurefireParser.kt
@@ -36,7 +36,7 @@ import org.sonar.api.measures.Metric
 import org.sonar.api.test.MutableTestPlan
 import org.sonar.api.test.TestCase
 import org.sonar.api.utils.log.Loggers
-import org.sonar.squidbridge.api.AnalysisException
+import org.sonar.java.AnalysisException
 import java.io.File
 import java.io.Serializable
 import java.util.*


### PR DESCRIPTION
I had no idea I could do this, but here: I'm opening a PR in place of @william-hill-online who fixed 7.3 compatibility but did so very sneakily 🤫