### PR TITLE
Add KotlinClasspath to detect .class files generated from .kt #77

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektPlugin.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/DetektPlugin.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.sonar
 
+import io.gitlab.arturbosch.detekt.sonar.foundation.KotlinClasspath
 import io.gitlab.arturbosch.detekt.sonar.foundation.KotlinLanguage
 import io.gitlab.arturbosch.detekt.sonar.foundation.propertyDefinitions
 import io.gitlab.arturbosch.detekt.sonar.jacoco.KotlinJaCoCoSensor
@@ -10,7 +11,6 @@ import io.gitlab.arturbosch.detekt.sonar.sensor.DetektSensor
 import io.gitlab.arturbosch.detekt.sonar.surefire.KotlinSurefireParser
 import io.gitlab.arturbosch.detekt.sonar.surefire.KotlinSurefireSensor
 import org.sonar.api.Plugin
-import org.sonar.java.JavaClasspath
 import org.sonar.java.JavaTestClasspath
 
 /**
@@ -25,7 +25,7 @@ class DetektPlugin : Plugin {
 				DetektSensor::class.java,
 				DetektRulesDefinition::class.java,
 				DetektMetrics::class.java,
-				JavaClasspath::class.java,
+				KotlinClasspath::class.java,
 				JavaTestClasspath::class.java,
 				KotlinJaCoCoSensor::class.java,
 				// Tests

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/foundation/KotlinClasspath.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/foundation/KotlinClasspath.kt
@@ -1,0 +1,62 @@
+package io.gitlab.arturbosch.detekt.sonar.foundation
+
+import org.sonar.api.batch.fs.FilePredicates
+import org.sonar.api.batch.fs.FileSystem
+import org.sonar.api.batch.fs.InputFile
+import org.sonar.api.config.Configuration
+import org.sonar.api.utils.log.Loggers
+import org.sonar.api.utils.log.Profiler
+import org.sonar.java.AbstractJavaClasspath
+import org.sonar.java.AnalysisException
+import org.sonar.java.JavaClasspath
+
+private val type = InputFile.Type.MAIN
+
+/**
+ * This class is based on [JavaClasspath] adding kotlin compiled .class files to binaries using the default kotlin .class files location.
+ */
+class KotlinClasspath(settings: Configuration?, fs: FileSystem?) : AbstractJavaClasspath(settings, fs, type) {
+    private val log = Loggers.get(JavaClasspath::class.java)
+
+    override fun init() {
+        if (!initialized) {
+            validateLibraries = fs.hasFiles(this.fs.predicates().all())
+            val profiler = Profiler.create(log).startInfo("KotlinClasspath initialization")
+            initialized = true
+
+            val libraries = this.getFilesFromProperty("sonar.java.libraries")
+            val binaryFiles = ArrayList(this.getFilesFromProperty("sonar.java.binaries"))
+
+            // assume a path with `kotlin-classes` within libraries is a kotlin .class files location
+            libraries.filter { it.path.contains("kotlin-classes") }.forEach {
+                libraries.remove(it)
+                binaryFiles.add(it)
+            }
+
+            if (binaryFiles.isEmpty() && hasMoreThanOneKotlinFile()) {
+                throw AnalysisException("Please provide compiled classes of your project with sonar.java.binaries property")
+            }
+
+            binaries = binaryFiles
+            if (libraries.isEmpty() && hasKotlinSources()) {
+                log.warn("Bytecode of dependencies was not provided for analysis of source files, you might end up with less precise results. Bytecode can be provided using sonar.java.libraries property")
+            }
+
+            elements = ArrayList(binaries)
+            elements.addAll(libraries)
+            profiler.stopInfo()
+        }
+    }
+
+    private fun hasKotlinSources(): Boolean {
+        return fs.hasFiles(ktPredicate(fs.predicates()))
+    }
+
+    private fun hasMoreThanOneKotlinFile(): Boolean {
+        return fs.inputFiles(ktPredicate(fs.predicates()))
+                .filterIndexed { i, _ -> i > 1 }
+                .any()
+    }
+
+    private fun ktPredicate(p: FilePredicates) = p.and(p.hasLanguage(KEY), p.hasType(type))
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJaCoCoSensor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJaCoCoSensor.kt
@@ -20,13 +20,13 @@
 package io.gitlab.arturbosch.detekt.sonar.jacoco
 
 import io.gitlab.arturbosch.detekt.sonar.foundation.KEY
+import io.gitlab.arturbosch.detekt.sonar.foundation.KotlinClasspath
 import io.gitlab.arturbosch.detekt.sonar.foundation.unwrap
 import org.sonar.api.batch.fs.FileSystem
 import org.sonar.api.batch.sensor.Sensor
 import org.sonar.api.batch.sensor.SensorContext
 import org.sonar.api.batch.sensor.SensorDescriptor
 import org.sonar.api.config.Configuration
-import org.sonar.java.JavaClasspath
 import org.sonar.plugins.jacoco.JaCoCoExtensions.*
 import org.sonar.plugins.jacoco.JaCoCoReportMerger
 import org.sonar.plugins.java.api.JavaResourceLocator
@@ -37,7 +37,7 @@ import java.util.*
 open class KotlinJaCoCoSensor(
 		fileSystem: FileSystem,
 		javaResourceLocator: JavaResourceLocator,
-		private val javaClasspath: JavaClasspath
+		private val kotlinClasspath: KotlinClasspath
 ) : Sensor {
 	private val javaResourceLocator = KotlinJavaResourceLocator(javaResourceLocator, fileSystem)
 
@@ -62,7 +62,7 @@ open class KotlinJaCoCoSensor(
 			reportMerged.parentFile.mkdirs()
 			JaCoCoReportMerger.mergeReports(reportMerged, *reportPaths.toTypedArray())
 		}
-		KotlinJacocoReportAnalyzer(javaResourceLocator, javaClasspath, report = reportMerged).analyse(context)
+		KotlinJacocoReportAnalyzer(javaResourceLocator, kotlinClasspath, report = reportMerged).analyse(context)
 	}
 
 	override fun toString(): String {

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJacocoReportAnalyzer.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJacocoReportAnalyzer.kt
@@ -20,6 +20,7 @@
 package io.gitlab.arturbosch.detekt.sonar.jacoco
 
 import com.google.common.collect.Maps
+import io.gitlab.arturbosch.detekt.sonar.foundation.KotlinClasspath
 import org.apache.commons.lang.StringUtils
 import org.jacoco.core.analysis.ICounter
 import org.jacoco.core.analysis.ISourceFileCoverage
@@ -28,7 +29,6 @@ import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.sensor.SensorContext
 import org.sonar.api.batch.sensor.coverage.CoverageType
 import org.sonar.api.batch.sensor.coverage.NewCoverage
-import org.sonar.java.JavaClasspath
 import org.sonar.plugins.jacoco.ExecutionDataVisitor
 import org.sonar.plugins.jacoco.JaCoCoExtensions
 import org.sonar.plugins.jacoco.JacocoReportReader
@@ -51,7 +51,7 @@ private const val NO_DATA_COLLECTED_MESSAGE =
 @Suppress("ALL")
 class KotlinJacocoReportAnalyzer @JvmOverloads constructor(
 		private val javaResourceLocator: JavaResourceLocator,
-		private val javaClasspath: JavaClasspath,
+		private val kotlinClasspath: KotlinClasspath,
 		private val readCoveragePerTests: Boolean = true,
 		private val report: File) {
 
@@ -73,7 +73,7 @@ class KotlinJacocoReportAnalyzer @JvmOverloads constructor(
 	}
 
 	fun analyse(context: SensorContext) {
-		for (classesDir in javaClasspath.binaryDirs) {
+		for (classesDir in kotlinClasspath.binaryDirs) {
 			populateClassFilesCache(classesDir, "")
 		}
 


### PR DESCRIPTION
jacoco coverage was not detected for .kt files as plugin was using JavaClasspath for coverage detection.
As a result, only .class files produced from .java files were used in detection of test coverage.
Here I introduce a hack, where I add a path with .class files from `libraries` to binaries for analysis.