### PR TITLE
Fix : The rule 'DetektRuleKey(...)' does not exist

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKey.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKey.kt
@@ -35,8 +35,23 @@ val ruleKeys = allLoadedRules.map { defineRuleKey(it) }
 val ruleKeyLookup = ruleKeys.map { it.ruleKey to it }.toMap()
 
 data class DetektRuleKey(private val repositoryKey: String,
-						 val ruleKey: String,
-						 val active: Boolean,
-						 val issue: Issue) : RuleKey(repositoryKey, ruleKey)
+                         val ruleKey: String,
+                         val active: Boolean,
+                         val issue: Issue) : RuleKey(repositoryKey, ruleKey) {
+    override fun hashCode(): Int {
+        return super.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+
+        if (other?.javaClass != javaClass && other?.javaClass != RuleKey::class.java) return false
+
+        val ruleKey = other as RuleKey?
+        return repository() == ruleKey!!.repository() && rule() == ruleKey.rule()
+
+        return super.equals(other)
+    }
+}
 
 private fun defineRuleKey(rule: Rule) = DetektRuleKey(DETEKT_REPOSITORY, rule.ruleId, rule.active, rule.issue)

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKeyTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKeyTest.kt
@@ -1,0 +1,25 @@
+package io.gitlab.arturbosch.detekt.sonar.rules
+
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.assertj.core.api.Assertions.*
+import org.junit.Test
+import org.sonar.api.rule.RuleKey
+
+class DetektRuleKeyTest {
+
+    @Test
+    fun `The rule 'DetektRuleKey(*)' does not exist`() {
+        var rulesByRuleKey = HashMap<RuleKey, Any?>()
+
+        rulesByRuleKey.put(RuleKey.of("detekt-kotlin", "NewLineAtEndOfFile"), "COUCOU")
+
+        var ruleKey = DetektRuleKey("detekt-kotlin", "NewLineAtEndOfFile", true,
+                Issue("NewLineAtEndOfFile", Severity.Style, debt = Debt(mins = 5), description = ""))
+
+        assertThat(rulesByRuleKey).containsKey(ruleKey)
+        assertThat(rulesByRuleKey.get(ruleKey)).isNotNull
+    }
+
+}


### PR DESCRIPTION
Hello,
Every time I tried to launch a sonarqube analysis (with gradle) the build failed with this error :

> The rule 'DetektRuleKey(repositoryKey=detekt-kotlin, ruleKey=NewLineAtEndOfFile, active=true, issue=Issue(id='NewLineAtEndOfFile', severity=Maintainability, debt=5min))' does not exist.

I noticed (during debug) that the probleme ocurred in class `org.sonar.api.batch.rule.internal.DefaultRules` from the sonarqube repository.

At line https://github.com/SonarSource/sonarqube/blob/3a08c1730f3fe248414add8fa57a61c5670e04c9/sonar-plugin-api/src/main/java/org/sonar/api/batch/rule/internal/DefaultRules.java#L53, we put an instance of :

> {RuleKey@26609} "detekt-kotlin:NewLineAtEndOfFile"  repository = "detekt-kotlin"  rule = "NewLineAtEndOfFile" toString = "detekt-kotlin:NewLineAtEndOfFile"

And at line https://github.com/SonarSource/sonarqube/blob/3a08c1730f3fe248414add8fa57a61c5670e04c9/sonar-plugin-api/src/main/java/org/sonar/api/batch/rule/internal/DefaultRules.java#L80, we are looking for the rule from an instance of :

>  ruleKey = {DetektRuleKey@34349} "DetektRuleKey(repositoryKey=detekt-kotlin, ruleKey=NewLineAtEndOfFile, active=true, issue=Issue(id='NewLineAtEndOfFile', severity=Style, debt=5min))" repositoryKey = "detekt-kotlin" ruleKey = "NewLineAtEndOfFile" active = true
>  issue = {Issue@34363} "Issue(id='NewLineAtEndOfFile', severity=Style, debt=5min)" repository = "detekt-kotlin" rule = "NewLineAtEndOfFile" toString = "detekt-kotlin:NewLineAtEndOfFile"

With my hack, we can now find the rule in the map and the analysis work. I hope it can help.

Maybe is's the same problem in https://github.com/arturbosch/sonar-kotlin/issues/83 ?